### PR TITLE
Update jquery.china_city.js.coffee

### DIFF
--- a/app/assets/javascripts/china_city/jquery.china_city.js.coffee
+++ b/app/assets/javascripts/china_city/jquery.china_city.js.coffee
@@ -10,6 +10,6 @@
           $.get "/china_city/#{$(@).val()}", (data) ->
             next_selects.first()[0].options.add(new Option(option[0], option[1])) for option in data
 
-  $ ->
+  $(document).on 'ready page:load', ->
     $('.city-group').china_city()
 )(jQuery)


### PR DESCRIPTION
同turbo-links一起使用时插件会失效，如果整个页面刷新就会好，估计原因是原来的插件只在ready的时候被初始化，但page:load或page:change时没有初始化。不知道是不是这样改？我本地改成这样后就好了