### PR TITLE
修复Turbolink下跨页面修改失效的情况

### DIFF
--- a/app/assets/javascripts/china_city/jquery.china_city.js.coffee
+++ b/app/assets/javascripts/china_city/jquery.china_city.js.coffee
@@ -13,6 +13,6 @@
             # init value after data completed.
             next_selects.trigger('china_city:load_data_completed');
 
-  $(document).on 'ready page:load', ->
+  $(document).on 'ready page:change', ->
     $('.city-group').china_city()
 )(jQuery)


### PR DESCRIPTION
在Turbolink下页面加载后会触发`page:load`和`page:change`两个事件，但页面跳转只会触发`page:change`。这里将`page:load`换成`page:change`保证了在页面跳转后仍能初始化。